### PR TITLE
Add basic tests and fix dummy data handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - run: pytest

--- a/app.py
+++ b/app.py
@@ -93,7 +93,8 @@ def get_backyard_temperature():
     # Use dummy data if enabled for testing purposes
     if USE_DUMMY_DATA:
         logger.info("Using dummy data for temperature.")
-        return 25  # Example dummy temperature value in Celsius
+        # Return a Celsius value and a placeholder for last updated
+        return 25, "N/A"
 
     # Prepare request headers for Home Assistant API
     headers = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==3.1.0
 requests==2.32.3
+pytest==8.2.2

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+import pytest
+
+os.environ['USE_DUMMY_DATA'] = 'true'
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+app = importlib.import_module('app')
+
+
+@pytest.fixture
+def client():
+    app.app.config['TESTING'] = True
+    return app.app.test_client()
+
+
+def test_celsius_to_fahrenheit():
+    assert app.celsius_to_fahrenheit(0) == 32
+    assert app.celsius_to_fahrenheit(25) == 77.0
+
+
+def test_index_returns_dummy_temp(client):
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b'25&deg;C' in response.data
+    assert b'77.0&deg;F' in response.data
+    assert b'Last updated: N/A' in response.data


### PR DESCRIPTION
## Summary
- fix `get_backyard_temperature` to return temperature and timestamp when using dummy data
- add pytest dependency
- introduce basic tests for temperature conversion and root endpoint
- add GitHub Actions workflow to run tests on pushes and pull requests
- return placeholder 'N/A' timestamp for dummy data and test for presence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbae5553b48324a935aa17daea7283