### PR TITLE
Add API path tests and improve error handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - run: pytest

--- a/app.py
+++ b/app.py
@@ -93,7 +93,8 @@ def get_backyard_temperature():
     # Use dummy data if enabled for testing purposes
     if USE_DUMMY_DATA:
         logger.info("Using dummy data for temperature.")
-        return 25  # Example dummy temperature value in Celsius
+        # Return a Celsius value and a placeholder for last updated
+        return 25, "N/A"
 
     # Prepare request headers for Home Assistant API
     headers = {
@@ -118,11 +119,11 @@ def get_backyard_temperature():
             return temperature, last_updated
         else:
             logger.error(f"Failed to get data from Home Assistant. Status Code: {response.status_code}")
-            return None
+            return None, None
     except requests.exceptions.RequestException as e:
         # Log any exception that occurs during the request
         logger.error(f"Error occurred while making request: {e}")
-        return None
+        return None, None
 
 # Utility function to convert Celsius to Fahrenheit
 def celsius_to_fahrenheit(celsius):
@@ -141,6 +142,7 @@ def index():
         # If temperature could not be retrieved, set to 'N/A'
         temperature_c = "N/A"
         temperature_f = "N/A"
+        last_updated = "N/A"
     else:
         # Convert Celsius to Fahrenheit if valid temperature is available
         temperature_f = celsius_to_fahrenheit(temperature_c)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==3.1.0
 requests==2.32.3
+pytest==8.2.2

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,101 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+
+import pytest
+
+# Ensure the application module can be imported
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def load_app(env=None):
+    """Import the app module with specific environment variables."""
+    env = env or {}
+    for key in [
+        "USE_DUMMY_DATA",
+        "HOME_ASSISTANT_URL",
+        "ENTITY_ID",
+        "API_TOKEN",
+    ]:
+        os.environ.pop(key, None)
+    os.environ.update(env)
+    if "app" in sys.modules:
+        del sys.modules["app"]
+    return importlib.import_module("app")
+
+
+@pytest.fixture
+def dummy_app():
+    return load_app({"USE_DUMMY_DATA": "true"})
+
+
+@pytest.fixture
+def client(dummy_app):
+    dummy_app.app.config["TESTING"] = True
+    return dummy_app.app.test_client()
+
+
+def test_celsius_to_fahrenheit(dummy_app):
+    assert dummy_app.celsius_to_fahrenheit(0) == 32
+    assert dummy_app.celsius_to_fahrenheit(25) == 77.0
+    assert dummy_app.celsius_to_fahrenheit(-40) == -40
+    assert dummy_app.celsius_to_fahrenheit(36.6) == 97.88
+
+
+def test_index_returns_dummy_temp(client):
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"25&deg;C" in response.data
+    assert b"77.0&deg;F" in response.data
+    assert b"Last updated: N/A" in response.data
+
+
+def test_get_backyard_temperature_success(monkeypatch):
+    app = load_app(
+        {
+            "USE_DUMMY_DATA": "false",
+            "HOME_ASSISTANT_URL": "http://example.com/",
+            "ENTITY_ID": "sensor.backyard_temperature",
+            "API_TOKEN": "token",
+        }
+    )
+
+    class DummyResponse:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"state": "30", "last_updated": "2024-01-01T00:00:00Z"}
+
+    monkeypatch.setattr(app.requests, "get", lambda *_, **__: DummyResponse())
+    temp, last_updated = app.get_backyard_temperature()
+    assert temp == 30.0
+    assert last_updated == "2024-01-01T00:00:00Z"
+
+
+def test_index_handles_api_error(monkeypatch):
+    app = load_app(
+        {
+            "USE_DUMMY_DATA": "false",
+            "HOME_ASSISTANT_URL": "http://example.com/",
+            "ENTITY_ID": "sensor.backyard_temperature",
+            "API_TOKEN": "token",
+        }
+    )
+
+    def raise_error(*args, **kwargs):
+        raise app.requests.exceptions.RequestException("boom")
+
+    monkeypatch.setattr(app.requests, "get", raise_error)
+    app.app.config["TESTING"] = True
+    client = app.app.test_client()
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"N/A&deg;C / N/A&deg;F" in response.data
+    assert b"Last updated: N/A" in response.data
+
+
+def test_missing_env_vars_raise_system_exit():
+    with pytest.raises(SystemExit):
+        load_app({"USE_DUMMY_DATA": "false"})


### PR DESCRIPTION
## Summary
- handle Home Assistant API failures by returning `(None, None)` and showing an `N/A` timestamp
- test API success and error paths, temperature conversion edge cases, and missing environment variables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbae5553b48324a935aa17daea7283